### PR TITLE
Use explicit parameter checks

### DIFF
--- a/HMDALoader.py
+++ b/HMDALoader.py
@@ -63,13 +63,13 @@ def get_hmda_files(
     df = df.filter(pl.col("FileType").str.to_lowercase() == file_type.lower())
 
     # Filter by Years
-    if min_year:
+    if min_year is not None:
         df = df.filter(pl.col("Year") >= min_year)
-    if max_year:
+    if max_year is not None:
         df = df.filter(pl.col("Year") <= max_year)
 
     # Filter by Extension Type
-    if extension:
+    if extension is not None:
         if extension.lower() == "parquet":
             df = df.filter(pl.col("FileParquet") == 1)
         if extension.lower() == "csv.gz":
@@ -78,7 +78,7 @@ def get_hmda_files(
             df = df.filter(pl.col("FileDTA") == 1)
 
     # Filter by Version Type
-    if version_type:
+    if version_type is not None:
         df = df.filter(pl.col("VersionType") == version_type)
 
     # Keep Most Recent File For Each Year
@@ -91,7 +91,7 @@ def get_hmda_files(
     folders = [Path(x) for x in df["FolderName"].to_list()]
     prefixes = df["FilePrefix"].to_list()
     files = [folder / prefix for folder, prefix in zip(folders, prefixes)]
-    if extension:
+    if extension is not None:
         files = [file.with_suffix(f".{extension}") for file in files]
 
     # Return File List

--- a/download_hmda_data.py
+++ b/download_hmda_data.py
@@ -176,7 +176,7 @@ def download_zip_files_from_url(
 
                         if overwrite_mode.lower() == "if_newer":
                             last_mod = head_resp.headers.get("Last-Modified")
-                            if last_mod:
+                            if last_mod is not None:
                                 try:
                                     remote_dt = parsedate_to_datetime(last_mod)
                                     local_dt = datetime.utcfromtimestamp(

--- a/import_support_functions.py
+++ b/import_support_functions.py
@@ -356,7 +356,7 @@ def destring_hmda_cols_pre2007(df: pl.DataFrame) -> pl.DataFrame:
         for col in numeric_columns
         if col in df.columns
     ]
-    if casts:
+    if len(casts) > 0:
         df = df.with_columns(casts)
 
     return df
@@ -648,7 +648,7 @@ def split_and_save_tract_variables(df, save_folder, file_name):
             df[tract_variable] = pd.to_numeric(df[tract_variable], errors="coerce")
 
         # Separate and DropExisting Tract Variables
-        if tract_variables:
+        if len(tract_variables) > 0:
             # Separate Tract Variables
             df_tract = df[
                 ["activity_year", "census_tract"] + tract_variables
@@ -668,7 +668,7 @@ def split_and_save_tract_variables(df, save_folder, file_name):
             df = df.with_columns(pl.col(tract_variable).cast(pl.Float64))
 
         # Separate and Drop Existing Tract Variables
-        if tract_variables:
+        if len(tract_variables) > 0:
             # Separate Tract Variables
             df_tract = df.select(
                 ["activity_year", "census_tract"] + tract_variables


### PR DESCRIPTION
## Summary
- avoid truthiness pitfalls in HMDA file filtering by checking optional parameters against `None`
- guard `Last-Modified` header handling with explicit `None` check
- ensure casting and tract variable separation only run when lists are non-empty

## Testing
- `ruff format HMDALoader.py download_hmda_data.py import_support_functions.py`
- `ruff check HMDALoader.py download_hmda_data.py import_support_functions.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4d0228d608332a4177db18c1a6b56