### PR TITLE
Add package initialization modules

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,17 @@
+"""HMDA Data Manager package."""
+
+from .import_support_functions import (
+    downcast_hmda_variables,
+    get_delimiter,
+    get_file_schema,
+    prepare_hmda_for_stata,
+    save_file_to_stata,
+)
+
+__all__ = [
+    "downcast_hmda_variables",
+    "get_delimiter",
+    "get_file_schema",
+    "prepare_hmda_for_stata",
+    "save_file_to_stata",
+]

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example usage of the HMDA Data Manager package."""

--- a/import_support_functions.py
+++ b/import_support_functions.py
@@ -7,7 +7,10 @@ import zipfile
 from csv import Sniffer
 from pathlib import Path
 
-import numpy as np
+try:
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
 import pandas as pd
 import polars as pl
 import pyarrow as pa

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Schema definitions for the HMDA Data Manager package."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the HMDA Data Manager package."""

--- a/tests/test_get_file_schema.py
+++ b/tests/test_get_file_schema.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 pytest.importorskip("polars")
 import polars as pl
-from import_support_functions import get_file_schema
+from hmda_data_manager import get_file_schema
 
 
 def test_polars_schema_returns_expected_types() -> None:


### PR DESCRIPTION
## Summary
- add `__init__` modules to convert repository into an importable package
- expose `get_file_schema` and related helpers at the package root
- update tests to import from the new package structure
- make numpy dependency optional for non-numeric helpers

## Testing
- `ruff format __init__.py examples/__init__.py schemas/__init__.py tests/__init__.py tests/test_get_file_schema.py`
- `ruff check __init__.py examples/__init__.py schemas/__init__.py tests/__init__.py tests/test_get_file_schema.py`
- `ruff check import_support_functions.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas'; attempted `python -m pip install numpy`, `python -m pip install pandas` but network access is restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68c643845f0483328e787027ba4febcb