### PR TITLE
Document save_file_to_stata and add regression test

### DIFF
--- a/import_support_functions.py
+++ b/import_support_functions.py
@@ -722,10 +722,23 @@ def downcast_hmda_variables(df):
 
 
 # Save to Stata
-def save_file_to_stata(file):
+def save_file_to_stata(file: Path) -> None:
+    """Convert a Parquet file to Stata format.
+
+    Parameters
+    ----------
+    file : Path
+        Path to the Parquet file to convert.
+
+    Returns
+    -------
+    None
+        This function saves the converted file and does not return anything.
+    """
+
     df = pd.read_parquet(file)
     df, variable_labels, value_labels = prepare_hmda_for_stata(df)
-    save_file_dta = file.replace(".parquet", ".dta")
+    save_file_dta = file.with_suffix(".dta")
     df.to_stata(
         save_file_dta,
         write_index=False,

--- a/tests/test_get_file_schema.py
+++ b/tests/test_get_file_schema.py
@@ -1,12 +1,12 @@
 import pytest
 from pathlib import Path
 
-pytest.importorskip("polars")
-import polars as pl
-from hmda_data_manager import get_file_schema
-
 
 def test_polars_schema_returns_expected_types() -> None:
+    pytest.importorskip("pandas")
+    pl = pytest.importorskip("polars")
+    from hmda_data_manager import get_file_schema
+
     schema = get_file_schema(Path("schemas/hmda_lar_schema_post2018.html"), "polars")
     assert schema["activity_year"] == pl.Int16
     assert schema["lei"] == pl.String

--- a/tests/test_save_file_to_stata.py
+++ b/tests/test_save_file_to_stata.py
@@ -1,0 +1,27 @@
+"""Tests for the :func:`save_file_to_stata` utility."""
+
+import pytest
+
+
+def test_save_file_to_stata_creates_dta(tmp_path, monkeypatch) -> None:
+    """Ensure the converter writes a ``.dta`` file when given a ``Path``."""
+
+    pd = pytest.importorskip("pandas")
+    from hmda_data_manager import save_file_to_stata, import_support_functions
+
+    # Create a simple Parquet file
+    df = pd.DataFrame({"a": [1, 2]})
+    parquet_path = tmp_path / "sample.parquet"
+    df.to_parquet(parquet_path)
+
+    # Stub out label preparation to avoid missing resource files
+    def fake_prepare(df):
+        return df, {}, {}
+
+    monkeypatch.setattr(
+        import_support_functions, "prepare_hmda_for_stata", fake_prepare
+    )
+
+    save_file_to_stata(parquet_path)
+
+    assert (tmp_path / "sample.dta").is_file()


### PR DESCRIPTION
## Summary
- document and type `save_file_to_stata`
- accept `Path` objects and use suffix-based path handling
- add regression test for `save_file_to_stata`
- defer test imports to runtime so optional deps can be skipped

## Testing
- `ruff check import_support_functions.py tests/test_save_file_to_stata.py tests/test_get_file_schema.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c647dd71848332b4dbbb1947a16871